### PR TITLE
✨ Feat(core) #55: Rename package namespace to `@synergy-design-system`

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-request-feature.md
+++ b/.github/ISSUE_TEMPLATE/component-request-feature.md
@@ -6,7 +6,7 @@ labels: component/change, enhancement, status/triage
 ---
 
 <!--
-Thank you for taking your time to request a new feature for a component of the SICK Design System. Please make sure to answer the questions below to give us more information about your request.
+Thank you for taking your time to request a new feature for a component of the Synergy Design System. Please make sure to answer the questions below to give us more information about your request.
 -->
 
 **Version**:

--- a/.github/ISSUE_TEMPLATE/component-request-new-component.md
+++ b/.github/ISSUE_TEMPLATE/component-request-new-component.md
@@ -6,7 +6,7 @@ labels: component/new, status/triage, enhancement
 ---
 
 <!--
-Thank you for taking your time to request a new component for the SICK Design System. Please make sure to answer the questions below to give us more information about your request.
+Thank you for taking your time to request a new component for the Synergy Design System. Please make sure to answer the questions below to give us more information about your request.
 -->
 
 **Version**:

--- a/.github/ISSUE_TEMPLATE/generic-bug.md
+++ b/.github/ISSUE_TEMPLATE/generic-bug.md
@@ -6,7 +6,7 @@ labels: bug, status/triage
 ---
 
 <!--
-Thank you for taking your time to report a bug in the SICK Design System. Please make sure to answer the questions below to give us more information about your request.
+Thank you for taking your time to report a bug in the Synergy Design System. Please make sure to answer the questions below to give us more information about your request.
 -->
 
 **Version**:
@@ -24,7 +24,7 @@ The issue happens in the following browser(s): _____
 
 **Questions**:
 
-- [ ] I have verified the bug exists in the latest version of `@sick-design-system/core` (e.g. via `npm install @sick-design-system/core@latest`).
+- [ ] I have verified the bug exists in the latest version of `@synergy-design-system/core` (e.g. via `npm install @synergy-design-system/core@latest`).
 - [ ] I can provide a simple, reproducible example of the issue (e.g. via code-sandbox or sample code, ...).
 - [ ] I would be willing to provide a PR for the issue.
 

--- a/.github/ISSUE_TEMPLATE/generic-feature.md
+++ b/.github/ISSUE_TEMPLATE/generic-feature.md
@@ -6,7 +6,7 @@ labels: status/triage, enhancement
 ---
 
 <!--
-Thank you for taking your time to request a new feature for the SICK Design System. Please make sure to answer the questions below to give us more information about your request.
+Thank you for taking your time to request a new feature for the Synergy Design System. Please make sure to answer the questions below to give us more information about your request.
 -->
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 Please have a look at the corresponding [packages](./packages) for a list of recent changes:
 
-- [@sick-design-system/css](./packages/css/CHANGELOG.md)
-- [@sick-design-system/components](./packages/components/CHANGELOG.md) 
-- [@sick-design-system/design-tokens](./packages/design-tokens/CHANGELOG.md)
-- [@sick-design-system/docs](./packages/docs/CHANGELOG.md)
-- [@sick-design-system/eslint-config-sds](./packages/eslint-config-sds/CHANGELOG.md)
-- [@sick-design-system/icons](./packages/icons/CHANGELOG.md)
-- [@sick-design-system/stylelint-config-sds](./packages/stylelint-config-sds/CHANGELOG.md)
+- [@synergy-design-system/css](./packages/css/CHANGELOG.md)
+- [@synergy-design-system/components](./packages/components/CHANGELOG.md) 
+- [@synergy-design-system/design-tokens](./packages/design-tokens/CHANGELOG.md)
+- [@synergy-design-system/docs](./packages/docs/CHANGELOG.md)
+- [@synergy-design-system/eslint-config-sds](./packages/eslint-config-sds/CHANGELOG.md)
+- [@synergy-design-system/icons](./packages/icons/CHANGELOG.md)
+- [@synergy-design-system/stylelint-config-sds](./packages/stylelint-config-sds/CHANGELOG.md)
 
 
 ### Item definitions
@@ -32,3 +32,4 @@ The following icons are used in commit messages and this changelog.
 ### ✨ Features
 
 - #4: Added github action for linting
+- #55: Rename package namespace to `@synergy-design-system`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# SICK Design System Contribution Guidelines
+# Synergy Design System Contribution Guidelines
 
 Thank you for investing your time to contribute to our project.
 We want to make sure to provide our users with a set of feature rich, high quality and easy to use web-components.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# SICK Design System
+# Synergy Design System
 
-Welcome to the home of the SICK Design System (**SDS**) 🎨.
+Welcome to the home of the Synergy Design System (**SDS**) 🎨.
 
 > **Warning**! Documentation is currently work in progress and we will update it while providing the bits and pieces of packages as we see fit. A complete developer documentation will be part of [our way to version 1.0](https://github.com/orgs/SickDesignSystem/projects/2/views/11?sliceBy%5Bvalue%5D=Basic+Setup).
 
 ---
 
-This repository provides a set of design-tokens, css styles, web-components and documentation that make it easy to use the SICK Design System in web based applications in a framework agnostic way.
+This repository provides a set of design-tokens, css styles, web-components and documentation that make it easy to use the Synergy Design System in web based applications in a framework agnostic way.
 
 The packages SDS consists of are mainly intended for usage in [SICK](https://www.sick.com) applications to ensure a unique look and feel across products, however you may also use them [for your own projects for free](./LICENSE) as well.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     { "name": "Stefan Reichert" },
     { "name": "Christian Schilling" }
   ],
-  "description": "SICK AG Design System for web based applications",
+  "description": "SICK AG Synergy Design System for web based applications",
   "license": "BSD-3-Clause",
   "engines": {
     "node": ">=18.17.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sick-design-system/root",
+  "name": "@synergy-design-system/root",
   "version": "1.0.0",
   "homepage": "https://github.com/SickDesignSystem/sds",
   "author": {

--- a/packages/components/.eslintrc
+++ b/packages/components/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@sick-design-system/eslint-config-sds/ts"
+    "@synergy-design-system/eslint-config-sds/ts"
   ],
   "parserOptions": {
     "project": "./tsconfig.json"

--- a/packages/components/.stylelintrc.json
+++ b/packages/components/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@sick-design-system/stylelint-config-sds"
+  "extends": "@synergy-design-system/stylelint-config-sds"
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,3 +22,4 @@ The following icons are used in commit messages and this changelog.
 
 - #18: Basic package setup, linting, dependencies and typescript
 - #18: Added initial `<sds-icon />` component
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,4 +1,4 @@
-# @sick-design-system/components
+# @synergy-design-system/components
 
 SDS Web Component library based on [@microsoft/fast-foundation](https://github.com/microsoft/fast).
 
@@ -9,9 +9,9 @@ SDS Web Component library based on [@microsoft/fast-foundation](https://github.c
 You may install the components via one of the following commands:
 
 ```bash
-npm install --save @sick-design-system/components
-yarn add @sick-design-system/components
-pnpm i @sick-design-system/components
+npm install --save @synergy-design-system/components
+yarn add @synergy-design-system/components
+pnpm i @synergy-design-system/components
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ This function is intended for quick testing of the library. It will provide **al
 Current feature set:
 
 - [x] Define all components available.
-- [ ] Add the `with-reset.css` stylesheet from `@sick-design-system/css` automatically.
+- [ ] Add the `with-reset.css` stylesheet from `@synergy-design-system/css` automatically.
 
 ```html
 <!DOCTYPE html>
@@ -38,10 +38,10 @@ Current feature set:
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module">
-    import { quickStart } from '@sick-design-system/components';
+    import { quickStart } from '@synergy-design-system/components';
     quickStart();
   </script>
-  <title>SICK Design System Demo</title>
+  <title>Synergy Design System Demo</title>
 </head>
 <body>
   <header>
@@ -77,15 +77,15 @@ It is also the suggested approach if you want to use a CDN for working with stat
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
 
   <!-- Load the design tokens and icons from anywhere you like -->
-  <link rel="stylesheet" href="https://path.to.cdn/@sick-design-system/design-tokens/build/tokens.css">
-  <link rel="stylesheet" href="https://path.to.cdn/@sick-design-system/icons/build/font.css">
+  <link rel="stylesheet" href="https://path.to.cdn/@synergy-design-system/design-tokens/build/tokens.css">
+  <link rel="stylesheet" href="https://path.to.cdn/@synergy-design-system/icons/build/font.css">
   
   <!-- or use a local version from npm -->
-  <link rel="stylesheet" href="node_modules/@sick-design-system/design-tokens/build/tokens.css">
-  <link rel="stylesheet" href="node_modules/@sick-design-system/icons/build/font.css">
+  <link rel="stylesheet" href="node_modules/@synergy-design-system/design-tokens/build/tokens.css">
+  <link rel="stylesheet" href="node_modules/@synergy-design-system/icons/build/font.css">
 
   <script type="module">
-    import { setup, SdsButton, SdsIcon, SdsLogo } from '@sick-design-system/components';
+    import { setup, SdsButton, SdsIcon, SdsLogo } from '@synergy-design-system/components';
     setup([
       SdsButton,
       SdsIcon,
@@ -93,7 +93,7 @@ It is also the suggested approach if you want to use a CDN for working with stat
     ]);
   </script>
 
-  <title>SICK Design System Demo</title>
+  <title>Synergy Design System Demo</title>
 </head>
 <body>
   <header>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,8 +10,8 @@
   },
   "description": "Web Components for the SICK Design System",
   "devDependencies": {
-    "@sick-design-system/eslint-config-sds": "workspace:^",
-    "@sick-design-system/stylelint-config-sds": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/stylelint-config-sds": "workspace:^",
     "eslint": "^8.47.0",
     "rimraf": "^5.0.1",
     "stylelint": "^15.10.3",
@@ -36,7 +36,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/components",
+  "name": "@synergy-design-system/components",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,7 +8,7 @@
     "@microsoft/fast-foundation": "^2.49.1",
     "tslib": "^2.6.2"
   },
-  "description": "Web Components for the SICK Design System",
+  "description": "Web Components for the Synergy Design System",
   "devDependencies": {
     "@synergy-design-system/eslint-config-sds": "workspace:^",
     "@synergy-design-system/stylelint-config-sds": "workspace:^",
@@ -32,6 +32,7 @@
     "Web Components",
     "Design System",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/components/src/setup.ts
+++ b/packages/components/src/setup.ts
@@ -17,7 +17,7 @@ const provideSDSDesignSystem = (element?: HTMLElement) => DesignSystem
  * @param components Array of components to load
  * @example
  * ```typescript
- * import { setup, SdsButton, SdsLogo } from '@sick-design-system/components';
+ * import { setup, SdsButton, SdsLogo } from '@synergy-design-system/components';
  * setup([ SdsButton, SdsLogo ]);
  * ```
  */

--- a/packages/css/.eslintrc
+++ b/packages/css/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "@sick-design-system/eslint-config-sds"
+  "extends": "@synergy-design-system/eslint-config-sds"
 }

--- a/packages/css/.stylelintrc.json
+++ b/packages/css/.stylelintrc.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@sick-design-system/stylelint-config-sds",
+  "extends": "@synergy-design-system/stylelint-config-sds",
   "ignoreFiles": ["build/*"]
 }

--- a/packages/css/CHANGELOG.md
+++ b/packages/css/CHANGELOG.md
@@ -28,4 +28,5 @@ The following icons are used in commit messages and this changelog.
 - #11: Added initial fouc prevention
 - #11: Added new variables as base for typo layout
 - #12: Added basic support for `sds-fade-in`, `sds-rotate-360` and `sds-scale` animations
-- #15: Added support for automatic loading of `@sick-design-system/icons`
+- #15: Added support for automatic loading of `@synergy-design-system/icons`
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,4 +1,4 @@
-# @sick-design-system/css
+# @synergy-design-system/css
 
 This package provides css styles that may be used in new web projects. It [sets a common baseline](./src/core/baseline.css) for projects by configuring [tags with default sizes and colors](./src/core/typo.css) and provides the css variables and [fonts](./src/core/fonts.css), as well as [icons](../icons/README.md) used throughout the SICK Design System components.
 
@@ -9,9 +9,9 @@ This package provides css styles that may be used in new web projects. It [sets 
 You may install all styles via one of the following commands:
 
 ```bash
-npm install --save @sick-design-system/css
-yarn add @sick-design-system/css
-pnpm i @sick-design-system/css
+npm install --save @synergy-design-system/css
+yarn add @synergy-design-system/css
+pnpm i @synergy-design-system/css
 ```
 
 ---
@@ -33,7 +33,7 @@ This package includes two versions of the css files. You may use either of them,
 <head>
 <!-- Example 1: Referencing directly in a HTML document -->
 <!-- Make sure to add the stylesheet before using any components -->
-<link rel="stylesheet" href="/node_modules/@sick-design-system/css/build/default.css" />
+<link rel="stylesheet" href="/node_modules/@synergy-design-system/css/build/default.css" />
 </head>
 <body>
   <div style="background: var(--sds-color-primary-500)">Content</div>
@@ -44,7 +44,7 @@ This package includes two versions of the css files. You may use either of them,
 <head>
 <!-- Example 2: Using the normalize version -->
 <!-- Make sure to add the stylesheet before using any components -->
-<link rel="stylesheet" href="/node_modules/@sick-design-system/css/build/with-reset.css" />
+<link rel="stylesheet" href="/node_modules/@synergy-design-system/css/build/with-reset.css" />
 </head>
 <body>
   <div style="background: var(--sds-color-primary-500)">Content</div>
@@ -55,13 +55,13 @@ This package includes two versions of the css files. You may use either of them,
 
 ## Font Support
 
-Supporting web-fonts as an npm module is more complex than it looks, as applications use various bundlers and each of them comes with its own syntax, configuration options and support for loading static files. Because of this, `@sick-design-system/css` comes with our chosen font [as an embeddable data URI](https://oreillymedia.github.io/Using_SVG/extras/ch07-dataURI-fonts.html). Caching is still possible with this approach and you will not have to adjust your application bundlers configuration at all.
+Supporting web-fonts as an npm module is more complex than it looks, as applications use various bundlers and each of them comes with its own syntax, configuration options and support for loading static files. Because of this, `@synergy-design-system/css` comes with our chosen font [as an embeddable data URI](https://oreillymedia.github.io/Using_SVG/extras/ch07-dataURI-fonts.html). Caching is still possible with this approach and you will not have to adjust your application bundlers configuration at all.
 
 ---
 
 ## Icon Support
 
-The package ships with a inlined version of Material Design Icons that is available as `@sick-design-system/icons`. Just add a `className` of **sds-icon** to an element to use the icon font. You may use it in the following way:
+The package ships with a inlined version of Material Design Icons that is available as `@synergy-design-system/icons`. Just add a `className` of **sds-icon** to an element to use the icon font. You may use it in the following way:
 
 ```html
 <!-- Display the material design menu glyph -->

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,6 +1,6 @@
 # @synergy-design-system/css
 
-This package provides css styles that may be used in new web projects. It [sets a common baseline](./src/core/baseline.css) for projects by configuring [tags with default sizes and colors](./src/core/typo.css) and provides the css variables and [fonts](./src/core/fonts.css), as well as [icons](../icons/README.md) used throughout the SICK Design System components.
+This package provides css styles that may be used in new web projects. It [sets a common baseline](./src/core/baseline.css) for projects by configuring [tags with default sizes and colors](./src/core/typo.css) and provides the css variables and [fonts](./src/core/fonts.css), as well as [icons](../icons/README.md) used throughout the Synergy Design System components.
 
 ---
 

--- a/packages/css/index.html
+++ b/packages/css/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Typography demo for @sick-design-system/css</title>
+  <title>Typography demo for @synergy-design-system/css</title>
   <link rel="stylesheet" href="build/with-reset.css" />
   <style>
   html, body {
@@ -125,7 +125,7 @@
 </head>
 <body>
   <header>
-    <h1>Demo for @sick-design-system/css</h1>
+    <h1>Demo for @synergy-design-system/css</h1>
     <nav>
       <a href="#typo">Typography</a>
       <a href="#animations">Animations</a>

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -7,7 +7,7 @@
     "@synergy-design-system/design-tokens": "workspace:^",
     "@synergy-design-system/icons": "workspace:^"
   },
-  "description": "Various CSS styles used in the SICK Design System",
+  "description": "Various CSS styles used in the Synergy Design System",
   "devDependencies": {
     "@synergy-design-system/eslint-config-sds": "workspace:^",
     "@synergy-design-system/stylelint-config-sds": "workspace:^",
@@ -38,6 +38,7 @@
     "Styles",
     "Reset",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -4,13 +4,13 @@
     "url": "https://www.sick.com"
   },
   "dependencies": {
-    "@sick-design-system/design-tokens": "workspace:^",
-    "@sick-design-system/icons": "workspace:^"
+    "@synergy-design-system/design-tokens": "workspace:^",
+    "@synergy-design-system/icons": "workspace:^"
   },
   "description": "Various CSS styles used in the SICK Design System",
   "devDependencies": {
-    "@sick-design-system/eslint-config-sds": "workspace:^",
-    "@sick-design-system/stylelint-config-sds": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/stylelint-config-sds": "workspace:^",
     "eslint": "^8.47.0",
     "normalize.css": "^8.0.1",
     "postcss": "^8.4.28",
@@ -42,7 +42,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/css",
+  "name": "@synergy-design-system/css",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/packages/css/src/versions/default.css
+++ b/packages/css/src/versions/default.css
@@ -1,10 +1,10 @@
 /**
- * Load design tokens from "@sick-design-system/design-tokens
+ * Load design tokens from "@synergy-design-system/design-tokens
  */
-@import url("@sick-design-system/design-tokens/build/css/tokens.css");
+@import url("@synergy-design-system/design-tokens/build/css/tokens.css");
 @import url("../core/fouc.css");
 @import url("../core/fonts.css");
-@import url("@sick-design-system/icons/build/font.css");
+@import url("@synergy-design-system/icons/build/font.css");
 @import url("../core/animations.css");
 @import url("../core/baseline.css");
 @import url("../core/typo.css");

--- a/packages/design-tokens/.eslintrc.json
+++ b/packages/design-tokens/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@sick-design-system/eslint-config-sds",
+  "extends": "@synergy-design-system/eslint-config-sds",
   "rules": {
     "import/no-extraneous-dependencies": ["error", {
       "devDependencies": true

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -23,9 +23,10 @@ The following icons are used in commit messages and this changelog.
 - #9: Initial README and CHANGELOG.
 - #9: Added core setup for style-dictionary.
 - #7: Added lint job `pnpm lint`
-- #11: Adjusted header to match `@sick-design-system/css`
+- #11: Adjusted header to match `@synergy-design-system/css`
 - #11: Added missing tokens for borders, dimensions, durations, opacity, shadow, spacing and typo
 - #11: Token names for colors should be using `kebab-case`
 - #11: Added ability to use css `calc` in output
 - #11: Restructured tokens, added missing ones.
 - #12: Added low level design tokens for animations.
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,6 +1,6 @@
-# @sick-design-system/design-tokens
+# @synergy-design-system/design-tokens
 
-This package provides the low level [design tokens](https://www.invisionapp.com/inside-design/design-tokens/) that form the core of the SICK Design System. It uses [style-dictionary](https://amzn.github.io/style-dictionary) to provide various output formats, as described below and allows bidirectional syncs between the original JSON files and [Figma Tokens Studio](https://tokens.studio/).
+This package provides the low level [design tokens](https://www.invisionapp.com/inside-design/design-tokens/) that form the core of the Synergy Design System. It uses [style-dictionary](https://amzn.github.io/style-dictionary) to provide various output formats, as described below and allows bidirectional syncs between the original JSON files and [Figma Tokens Studio](https://tokens.studio/).
 
 ---
 
@@ -9,9 +9,9 @@ This package provides the low level [design tokens](https://www.invisionapp.com/
 You may install this package using one of the following ways:
 
 ```bash
-npm install --save @sick-design-system/design-tokens
-yarn add @sick-design-system/design-tokens
-pnpm i @sick-design-system/design-tokens
+npm install --save @synergy-design-system/design-tokens
+yarn add @synergy-design-system/design-tokens
+pnpm i @synergy-design-system/design-tokens
 ```
 
 ---
@@ -51,7 +51,7 @@ This is the preferred way to use the SDS design tokens. Custom-Properties have t
 <head>
 <!-- Example 1: Referencing directly in a HTML document -->
 <!-- Make sure to add the stylesheet before using any components -->
-<link rel="stylesheet" href="/node_modules/@sick-design-system/design-tokens/build/css/tokens.css" />
+<link rel="stylesheet" href="/node_modules/@synergy-design-system/design-tokens/build/css/tokens.css" />
 </head>
 <body>
   <div style="background: var(--sds-color-primary-500)">Content</div>"
@@ -61,11 +61,11 @@ This is the preferred way to use the SDS design tokens. Custom-Properties have t
 ```javascript
 // Example 2: Referencing via JavaScript, e.g. when using webpack or vite
 // Note your bundler may need to be setup to allow css files!
-import '@sick-design-system/design-tokens/build/css/tokens.css';
+import '@synergy-design-system/design-tokens/build/css/tokens.css';
 
 // Example 3: If your system supports package.json exports fields (like vite does),
 // you may optionally also use the following alias:
-import '@sick-design-system/design-tokens/css';
+import '@synergy-design-system/design-tokens/css';
 ```
 
 ### 2. SASS
@@ -77,7 +77,7 @@ If you already have a SASS toolchain, you may also use our scss variables. Use t
 // If not using webpack sass loader, you may need a sass import helper like
 // https://www.npmjs.com/package/node-sass-package-importer
 // to make it work.
-@import '~sick-design-system/design-tokens/build/scss/tokens.scss';
+@import '~@synergy-design-system/design-tokens/build/scss/tokens.scss';
 
 // You may now use the variables in your sass files
 .box {
@@ -94,8 +94,8 @@ We also provide all tokens as JavaScript constants. This may be needed when you 
 
 ```javascript
 // Note! We do NOT provide a default export, so you will have to use one of the syntaxes below to import a token.
-import * as allTokens from '@sick-design-system/design-tokens';
-import { sdsColorPrimary500 } from '@sick-design-system/design-tokens';
+import * as allTokens from '@synergy-design-system/design-tokens';
+import { sdsColorPrimary500 } from '@synergy-design-system/design-tokens';
 
 console.log(allTokens.sdsColorPrimary500); // <- #007CC1
 console.log(sdsColorPrimary500);           // <- #007CC1

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -3,7 +3,7 @@
     "name": "SICK Integrated Automation - UX and UI Services Team",
     "url": "https://www.sick.com"
   },
-  "description": "Design tokens for the SICK Design System",
+  "description": "Design tokens for the Synergy Design System",
   "devDependencies": {
     "@synergy-design-system/eslint-config-sds": "workspace:^",
     "@tokens-studio/sd-transforms": "^0.11.0",
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/SickDesignSystem/sds/tree/main/packages/design-tokens",
   "keywords": [
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System",
     "Design Tokens"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -5,7 +5,7 @@
   },
   "description": "Design tokens for the SICK Design System",
   "devDependencies": {
-    "@sick-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
     "@tokens-studio/sd-transforms": "^0.11.0",
     "chalk": "^5.3.0",
     "eslint": "^8.47.0",
@@ -29,7 +29,7 @@
     "Design Tokens"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/design-tokens",
+  "name": "@synergy-design-system/design-tokens",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/packages/docs/.eslintrc
+++ b/packages/docs/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@sick-design-system/eslint-config-sds/ts",
+    "@synergy-design-system/eslint-config-sds/ts",
     "plugin:storybook/recommended"
   ],
   "parserOptions": {

--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/html';
-import '@sick-design-system/css/default.css';
-import { quickStart } from '@sick-design-system/components';
-import * as tokens from '@sick-design-system/design-tokens';
+import '@synergy-design-system/css/default.css';
+import { quickStart } from '@synergy-design-system/components';
+import * as tokens from '@synergy-design-system/design-tokens';
 
 quickStart();
 

--- a/packages/docs/.stylelintrc.json
+++ b/packages/docs/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@sick-design-system/stylelint-config-sds"
+  "extends": "@synergy-design-system/stylelint-config-sds"
 }

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ The following icons are used in commit messages and this changelog.
 ### 📚 Doc
 
 - #22: Added Welcome page and colors
-- #22: Added `@sick-design-system/design-tokens` Changelog and Readme, as well as color tokens
+- #22: Added `@synergy-design-system/design-tokens` Changelog and Readme, as well as color tokens
 
 ### ✨ Features
 
@@ -30,8 +30,9 @@ The following icons are used in commit messages and this changelog.
 - #20: Add first fast component for testing purposes
 - #20: Ignore linting the `stories` folder.
 - #22: Add support for storybook badges
+- #55: Rename package namespace to `@synergy-design-system`
 
 ### ⛔ Removals
 
 - #20: Removed Storybook demo content
-- #18: Moved `<SdsLogo />` component to `@sick-design-system/components`
+- #18: Moved `<SdsLogo />` component to `@synergy-design-system/components`

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,1 +1,1 @@
-# @sick-design-system/docs
+# @synergy-design-system/docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
     "change-case": "^4.1.2",
     "material-icons": "^1.13.10"
   },
-  "description": "Storybook demo for static assets and components of the SICK Design System",
+  "description": "Storybook demo for static assets and components of the Synergy Design System",
   "devDependencies": {
     "@geometricpanda/storybook-addon-badges": "^2.0.0",
     "@microsoft/fast-element": "^1.12.0",
@@ -41,6 +41,7 @@
     "Storybook",
     "Design System Demo",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,9 +4,9 @@
     "url": "https://www.sick.com"
   },
   "dependencies": {
-    "@sick-design-system/components": "workspace:^",
-    "@sick-design-system/css": "workspace:^",
-    "@sick-design-system/design-tokens": "workspace:^",
+    "@synergy-design-system/components": "workspace:^",
+    "@synergy-design-system/css": "workspace:^",
+    "@synergy-design-system/design-tokens": "workspace:^",
     "change-case": "^4.1.2",
     "material-icons": "^1.13.10"
   },
@@ -15,8 +15,8 @@
     "@geometricpanda/storybook-addon-badges": "^2.0.0",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.1",
-    "@sick-design-system/eslint-config-sds": "workspace:^",
-    "@sick-design-system/stylelint-config-sds": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/stylelint-config-sds": "workspace:^",
     "@storybook/addon-a11y": "^7.4.0",
     "@storybook/addon-essentials": "^7.4.0",
     "@storybook/addon-interactions": "^7.4.0",
@@ -45,7 +45,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/docs",
+  "name": "@synergy-design-system/docs",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/packages/docs/src/helpers/colors.ts
+++ b/packages/docs/src/helpers/colors.ts
@@ -1,5 +1,5 @@
 import { paramCase } from 'change-case';
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 
 /**
  * Get all colors from a palette as object

--- a/packages/docs/stories/Index.mdx
+++ b/packages/docs/stories/Index.mdx
@@ -2,17 +2,17 @@ import { Meta } from "@storybook/blocks";
 
 <Meta title="Welcome" />
 
-# SICK Design System
+# Synergy Design System
 
 <div className="sds-intro">
   <div className="left">
     Our design system helps us both work together efficiently and build a great experience for our users.
 
-    The SICK Design System (SDS) provides a centralized, living source for look and feel of our digital products to create consistent user interfaces across all digital SICK products.
+    The Synergy Design System (SDS) provides a centralized, living source for look and feel of our digital products to create consistent user interfaces across all digital SICK products.
 
     This comprehensive guide and resource library contains everything you’ll need to design and develop digital interfaces with SICK. Here you’ll find resources for creating a unified, consistent experience with design foundations, basic design elements, patterns and best practices to help you focus on the unique parts of your work.
   </div>
-  <img src="/sds.png" alt="SICK Design System" />
+  <img src="/sds.png" alt="Synergy Design System" />
 </div>
 
 <style>

--- a/packages/docs/stories/components/icon.stories.ts
+++ b/packages/docs/stories/components/icon.stories.ts
@@ -2,7 +2,7 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
-import type { Icon } from '@sick-design-system/components/dist/types/components/icon/class';
+import type { Icon } from '@synergy-design-system/components/dist/types/components/icon/class';
 import { renderComponent } from '../../src/helpers';
 import type { StoryArgs } from '../../src/helpers';
 

--- a/packages/docs/stories/components/logo.stories.ts
+++ b/packages/docs/stories/components/logo.stories.ts
@@ -1,7 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
-import type { Logo } from '@sick-design-system/components/dist/types/components/logo/class';
+import type { Logo } from '@synergy-design-system/components/dist/types/components/logo/class';
 import { renderComponent } from '../../src/helpers';
 import type { StoryArgs } from '../../src/helpers';
 

--- a/packages/docs/stories/foundations/Colors/Index.mdx
+++ b/packages/docs/stories/foundations/Colors/Index.mdx
@@ -1,5 +1,5 @@
 import { Meta , ColorPalette, ColorItem } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 
 <Meta title="Foundations/Color" />
 

--- a/packages/docs/stories/foundations/Colors/MainColors.mdx
+++ b/packages/docs/stories/foundations/Colors/MainColors.mdx
@@ -1,5 +1,5 @@
 import { Meta , ColorPalette, ColorItem } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 import {
   getAccentColorPalette,
   getPrimaryColorPalette,

--- a/packages/docs/stories/foundations/Colors/NeutralColors.mdx
+++ b/packages/docs/stories/foundations/Colors/NeutralColors.mdx
@@ -1,5 +1,5 @@
 import { Meta , ColorPalette, ColorItem } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 import {
   getNeutralDarkPalette,
   getNeutralMidPalette,

--- a/packages/docs/stories/foundations/Colors/SecondaryColors.mdx
+++ b/packages/docs/stories/foundations/Colors/SecondaryColors.mdx
@@ -1,5 +1,5 @@
 import { Meta , ColorPalette, ColorItem } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 import {
   getAddonsColorPalette,
 } from '../../../src/helpers';

--- a/packages/docs/stories/foundations/Colors/StatusColors.mdx
+++ b/packages/docs/stories/foundations/Colors/StatusColors.mdx
@@ -1,5 +1,5 @@
 import { Meta , ColorPalette, ColorItem } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 
 <Meta title="Foundations/Color/Status" />
 

--- a/packages/docs/stories/foundations/Tokens/Colors.mdx
+++ b/packages/docs/stories/foundations/Tokens/Colors.mdx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/blocks";
-import * as tokens from '@sick-design-system/design-tokens';
+import * as tokens from '@synergy-design-system/design-tokens';
 import { CopyToClipBoard } from '../../../src/Clipboard.tsx';
 
 import {

--- a/packages/eslint-config-sds/CHANGELOG.md
+++ b/packages/eslint-config-sds/CHANGELOG.md
@@ -25,3 +25,4 @@ The following icons are used in commit messages and this changelog.
 - #7: Added core setup for eslint JavaScript and TypeScript versions.
 - #8: Added lint job for checking the lint configuration against its own rules.
 - #20: Removed `arrow-parens` rule as fasts template syntax uses it extensively
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/eslint-config-sds/README.md
+++ b/packages/eslint-config-sds/README.md
@@ -1,6 +1,6 @@
-# @sick-design-system/eslint-config-sds
+# @synergy-design-system/eslint-config-sds
 
-This package provides common linting rules used throughout the SICK Design System. It is primarily based on `eslint-config-airbnb` and supports JavaScript and TypeScript projects.
+This package provides common linting rules used throughout the Synergy Design System. It is primarily based on `eslint-config-airbnb` and supports JavaScript and TypeScript projects.
 
 ---
 
@@ -9,9 +9,9 @@ This package provides common linting rules used throughout the SICK Design Syste
 Please issue one of the following commands to install the linting toolchain:
 
 ```bash
-npm install --save-dev eslint @sick-design-system/eslint-config-sds
-yarn add --dev eslint @sick-design-system/eslint-config-sds
-pnpm i -D eslint @sick-design-system/eslint-config-sds
+npm install --save-dev eslint @synergy-design-system/eslint-config-sds
+yarn add --dev eslint @synergy-design-system/eslint-config-sds
+pnpm i -D eslint @synergy-design-system/eslint-config-sds
 ```
 
 ## Configuration
@@ -22,7 +22,7 @@ Create a new `.eslintrc.json` file with the following content:
 
 ```json
 {
-  "extends": "@sick-design-system/eslint-config-sds"
+  "extends": "@synergy-design-system/eslint-config-sds"
 }
 ```
 
@@ -34,7 +34,7 @@ Create a new `.eslintrc.json` file with the following content:
 
 ```json
 {
-  "extends": "@sick-design-system/eslint-config-sds/ts",
+  "extends": "@synergy-design-system/eslint-config-sds/ts",
   "parserOptions": {
     "project": "./tsconfig.json"
   }

--- a/packages/eslint-config-sds/package.json
+++ b/packages/eslint-config-sds/package.json
@@ -9,7 +9,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0"
   },
-  "description": "ESLint core rules used in the SICK Design System",
+  "description": "ESLint core rules used in the Synergy Design System",
   "devDependencies": {
     "eslint": "^8.47.0"
   },
@@ -22,6 +22,7 @@
     "eslint",
     "eslintconfig",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/eslint-config-sds/package.json
+++ b/packages/eslint-config-sds/package.json
@@ -26,7 +26,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/eslint-config-sds",
+  "name": "@synergy-design-system/eslint-config-sds",
   "peerDependencies": {
     "eslint": ">8.0.0"
   },

--- a/packages/icons/.eslintrc
+++ b/packages/icons/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "@sick-design-system/eslint-config-sds"
+  "extends": "@synergy-design-system/eslint-config-sds"
 }

--- a/packages/icons/.stylelintrc.json
+++ b/packages/icons/.stylelintrc.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@sick-design-system/stylelint-config-sds",
+  "extends": "@synergy-design-system/stylelint-config-sds",
   "ignoreFiles": ["build/*"]
 }

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -21,3 +21,4 @@ The following icons are used in commit messages and this changelog.
 ### ✨ Features
 
 - #15: Added core setup for icons package
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,4 +1,4 @@
-# @sick-design-system/icons
+# @synergy-design-system/icons
 
 This package provides [Material Icons](https://fonts.google.com/icons) that are used throughout the SICK Design System in an easy to use package. The font is loaded [as an embeddable data URI](https://oreillymedia.github.io/Using_SVG/extras/ch07-dataURI-fonts.html). Caching is still possible with this approach and you will not have to adjust your application bundlers configuration at all.
 
@@ -9,9 +9,9 @@ This package provides [Material Icons](https://fonts.google.com/icons) that are 
 You may install all styles via one of the following commands:
 
 ```bash
-npm install --save @sick-design-system/icons
-yarn add @sick-design-system/icons
-pnpm i @sick-design-system/icons
+npm install --save @synergy-design-system/icons
+yarn add @synergy-design-system/icons
+pnpm i @synergy-design-system/icons
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ Just include the provided `font.css` file in the `build/` directory. It will hav
 <head>
 <!-- Example 1: Referencing directly in a HTML document -->
 <!-- Make sure to add the stylesheet before using any components -->
-<link rel="stylesheet" href="/node_modules/@sick-design-system/icons/build/font.css" />
+<link rel="stylesheet" href="/node_modules/@synergy-design-system/icons/build/font.css" />
 </head>
 <body>
   <span class="sds-icon">
@@ -34,11 +34,11 @@ Just include the provided `font.css` file in the `build/` directory. It will hav
 ```javascript
 // Example 2: Referencing via JavaScript, e.g. when using webpack or vite
 // Note your bundler may need to be setup to allow css files!
-import '@sick-design-system/icons/build/font.css';
+import '@synergy-design-system/icons/build/font.css';
 
 // Example 3: If your system supports package.json exports fields (like vite does),
 // you may optionally also use the following alias:
-import '@sick-design-system/icons';
+import '@synergy-design-system/icons';
 ```
 
 ---
@@ -54,7 +54,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 // Vite Imports this as string only when using ?inline
-import iconDefinition from '@sick-design-system/icons/icon.css?inline';
+import iconDefinition from '@synergy-design-system/icons/icon.css?inline';
 import otherStyles from './iconDemo.styles.css?inline';
 
 @customElement('icon-demo')

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,6 +1,6 @@
 # @synergy-design-system/icons
 
-This package provides [Material Icons](https://fonts.google.com/icons) that are used throughout the SICK Design System in an easy to use package. The font is loaded [as an embeddable data URI](https://oreillymedia.github.io/Using_SVG/extras/ch07-dataURI-fonts.html). Caching is still possible with this approach and you will not have to adjust your application bundlers configuration at all.
+This package provides [Material Icons](https://fonts.google.com/icons) that are used throughout the Synergy Design System in an easy to use package. The font is loaded [as an embeddable data URI](https://oreillymedia.github.io/Using_SVG/extras/ch07-dataURI-fonts.html). Caching is still possible with this approach and you will not have to adjust your application bundlers configuration at all.
 
 ---
 

--- a/packages/icons/index.html
+++ b/packages/icons/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Typography demo for @sick-design-system/css</title>
-  <link rel="stylesheet" href="node_modules/@sick-design-system/design-tokens/build/css/tokens.css" />
+  <title>Typography demo for @synergy-design-system/css</title>
+  <link rel="stylesheet" href="node_modules/@synergy-design-system/design-tokens/build/css/tokens.css" />
   <link rel="stylesheet" href="build/font.css" />
   <style>
   html, body {
@@ -93,7 +93,7 @@
 </head>
 <body>
   <header>
-    <h1>Demo for @sick-design-system/icons</h1>
+    <h1>Demo for @synergy-design-system/icons</h1>
   </header>
   <main>
     <ul class="icon-grid"></ul>

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,7 +3,7 @@
     "name": "SICK Integrated Automation - UX and UI Services Team",
     "url": "https://www.sick.com"
   },
-  "description": "Icon font used in the SICK Design System",
+  "description": "Icon font used in the Synergy Design System",
   "devDependencies": {
     "@synergy-design-system/design-tokens": "workspace:^",
     "@synergy-design-system/eslint-config-sds": "workspace:^",
@@ -35,6 +35,7 @@
     "Webfont",
     "CSS",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,9 +5,9 @@
   },
   "description": "Icon font used in the SICK Design System",
   "devDependencies": {
-    "@sick-design-system/design-tokens": "workspace:^",
-    "@sick-design-system/eslint-config-sds": "workspace:^",
-    "@sick-design-system/stylelint-config-sds": "workspace:^",
+    "@synergy-design-system/design-tokens": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/stylelint-config-sds": "workspace:^",
     "eslint": "^8.47.0",
     "material-icons": "^1.13.10",
     "postcss": "^8.4.28",
@@ -39,7 +39,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/icons",
+  "name": "@synergy-design-system/icons",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/packages/stylelint-config-sds/.eslintrc
+++ b/packages/stylelint-config-sds/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "@sick-design-system/eslint-config-sds"
+  "extends": "@synergy-design-system/eslint-config-sds"
 }

--- a/packages/stylelint-config-sds/CHANGELOG.md
+++ b/packages/stylelint-config-sds/CHANGELOG.md
@@ -21,3 +21,4 @@ The following icons are used in commit messages and this changelog.
 ### ✨ Features
 
 - #8: Added core setup for stylelint for easy css linting.
+- #55: Rename package namespace to `@synergy-design-system`

--- a/packages/stylelint-config-sds/README.md
+++ b/packages/stylelint-config-sds/README.md
@@ -1,6 +1,6 @@
-# @sick-design-system/stylelint-config-sds
+# @synergy-design-system/stylelint-config-sds
 
-This package provides common linting rules for CSS used throughout the SICK Design System. It is primarily based on `stylelint-config-standard` and supports css, JavaScript and TypeScript files and lit and fast css helper functions via [postcss-lit](https://github.com/43081j/postcss-lit).
+This package provides common linting rules for CSS used throughout the Synergy Design System. It is primarily based on `stylelint-config-standard` and supports css, JavaScript and TypeScript files and lit and fast css helper functions via [postcss-lit](https://github.com/43081j/postcss-lit).
 
 ---
 
@@ -9,9 +9,9 @@ This package provides common linting rules for CSS used throughout the SICK Desi
 Please issue one of the following commands to install the linting toolchain:
 
 ```bash
-npm install --save-dev stylelint @sick-design-system/styling-config-sds
-yarn add --dev stylelint @sick-design-system/styling-config-sds
-pnpm i -D stylelint @sick-design-system/styling-config-sds
+npm install --save-dev stylelint @synergy-design-system/styling-config-sds
+yarn add --dev stylelint @synergy-design-system/styling-config-sds
+pnpm i -D stylelint @synergy-design-system/styling-config-sds
 ```
 
 ## Configuration
@@ -20,7 +20,7 @@ Create a new `.stylelintrc.json` file with the following content:
 
 ```json
 {
-  "extends": "@sick-design-system/stylelint-config-sds",
+  "extends": "@synergy-design-system/stylelint-config-sds",
   "rules": {
     "example-rule": null
   }

--- a/packages/stylelint-config-sds/package.json
+++ b/packages/stylelint-config-sds/package.json
@@ -8,7 +8,7 @@
     "stylelint-config-standard": "^34.0.0",
     "stylelint-order": "^6.0.3"
   },
-  "description": "Stylelint core rules used in the SICK Design System",
+  "description": "Stylelint core rules used in the Synergy Design System",
   "devDependencies": {
     "@microsoft/fast-element": "^1.12.0",
     "@synergy-design-system/eslint-config-sds": "workspace:^",
@@ -29,6 +29,7 @@
     "stylelint",
     "stylelintconfig",
     "SDS",
+    "Synergy Design System",
     "SICK",
     "SICK Design System"
   ],

--- a/packages/stylelint-config-sds/package.json
+++ b/packages/stylelint-config-sds/package.json
@@ -11,7 +11,7 @@
   "description": "Stylelint core rules used in the SICK Design System",
   "devDependencies": {
     "@microsoft/fast-element": "^1.12.0",
-    "@sick-design-system/eslint-config-sds": "workspace:^",
+    "@synergy-design-system/eslint-config-sds": "workspace:^",
     "eslint": "^8.47.0",
     "lit": "^2.8.0",
     "stylelint": "^15.10.3"
@@ -33,7 +33,7 @@
     "SICK Design System"
   ],
   "license": "BSD-3-Clause",
-  "name": "@sick-design-system/stylelint-config-sds",
+  "name": "@synergy-design-system/stylelint-config-sds",
   "repository": {
     "type": "git",
     "url": "https://github.com/SickDesignSystem/sds.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
     devDependencies:
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
-      '@sick-design-system/stylelint-config-sds':
+      '@synergy-design-system/stylelint-config-sds':
         specifier: workspace:^
         version: link:../stylelint-config-sds
       eslint:
@@ -41,17 +41,17 @@ importers:
 
   packages/css:
     dependencies:
-      '@sick-design-system/design-tokens':
+      '@synergy-design-system/design-tokens':
         specifier: workspace:^
         version: link:../design-tokens
-      '@sick-design-system/icons':
+      '@synergy-design-system/icons':
         specifier: workspace:^
         version: link:../icons
     devDependencies:
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
-      '@sick-design-system/stylelint-config-sds':
+      '@synergy-design-system/stylelint-config-sds':
         specifier: workspace:^
         version: link:../stylelint-config-sds
       eslint:
@@ -87,7 +87,7 @@ importers:
 
   packages/design-tokens:
     devDependencies:
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
       '@tokens-studio/sd-transforms':
@@ -108,13 +108,13 @@ importers:
 
   packages/docs:
     dependencies:
-      '@sick-design-system/components':
+      '@synergy-design-system/components':
         specifier: workspace:^
         version: link:../components
-      '@sick-design-system/css':
+      '@synergy-design-system/css':
         specifier: workspace:^
         version: link:../css
-      '@sick-design-system/design-tokens':
+      '@synergy-design-system/design-tokens':
         specifier: workspace:^
         version: link:../design-tokens
       change-case:
@@ -133,10 +133,10 @@ importers:
       '@microsoft/fast-foundation':
         specifier: ^2.49.1
         version: 2.49.1
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
-      '@sick-design-system/stylelint-config-sds':
+      '@synergy-design-system/stylelint-config-sds':
         specifier: workspace:^
         version: link:../stylelint-config-sds
       '@storybook/addon-a11y':
@@ -212,13 +212,13 @@ importers:
 
   packages/icons:
     devDependencies:
-      '@sick-design-system/design-tokens':
+      '@synergy-design-system/design-tokens':
         specifier: workspace:^
         version: link:../design-tokens
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
-      '@sick-design-system/stylelint-config-sds':
+      '@synergy-design-system/stylelint-config-sds':
         specifier: workspace:^
         version: link:../stylelint-config-sds
       eslint:
@@ -267,7 +267,7 @@ importers:
       '@microsoft/fast-element':
         specifier: ^1.12.0
         version: 1.12.0
-      '@sick-design-system/eslint-config-sds':
+      '@synergy-design-system/eslint-config-sds':
         specifier: workspace:^
         version: link:../eslint-config-sds
       eslint:


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds the changes for renaming

### 🎫 Issues

Closes #55.

## 👩‍💻 Reviewer Notes

- I have renamed all static files and also the lock files.
- You will have to run `pnpm i -r` in the root to make sure all packages are linked correctly.
- The prefix in the current `component` package is still `sds-` and not `syn-`, as we will remove this package anyways.